### PR TITLE
to avoid host not found in upstream "artifactory"

### DIFF
--- a/swarm/artifactory-pro.yml
+++ b/swarm/artifactory-pro.yml
@@ -55,6 +55,8 @@ services:
      - 443:443
     depends_on:
      - artifactory
+    links:
+     - artifactory
     deploy:
       mode: replicated
       replicas: 1


### PR DESCRIPTION
linking artifactory container to nginx is mandetory due to the nginx configuration provided.