### PR TITLE
Remove chown from dcs for artifactory HA (6.9)

### DIFF
--- a/openshift/artifactory/artifactory-ha-nfs/artifactory-primary-deployment.yaml
+++ b/openshift/artifactory/artifactory-ha-nfs/artifactory-primary-deployment.yaml
@@ -31,24 +31,6 @@ objects:
                 serviceAccountName: ${SERVICE_ACCOUNT}
 
                 initContainers:
-                  - name: set-volume-ownership
-                    image: ${INIT_CONTAINER_IMAGE}
-                    command: ["sh", "-c", "chown -R 1030:1030 /var/opt/jfrog/artifactory"]
-                    volumeMounts:
-                      - name: artifactory
-                        mountPath: /var/opt/jfrog/artifactory
-                  - name: set-data-volume-ownership
-                    image: ${INIT_CONTAINER_IMAGE}
-                    command: ["sh", "-c", "chown -R 1030:1030 /var/opt/jfrog/data"]
-                    volumeMounts:
-                      - name: artifactory-data
-                        mountPath: /var/opt/jfrog/data
-                  - name: set-backup-volume-ownership
-                    image: ${INIT_CONTAINER_IMAGE}
-                    command: ["sh", "-c", "chown -R 1030:1030 /var/opt/jfrog/backup"]
-                    volumeMounts:
-                      - name: artifactory-backup
-                        mountPath: /var/opt/jfrog/backup
                   - name: remove-lost-found
                     image: ${INIT_CONTAINER_IMAGE}
                     command: ["sh", "-c", "rm -rf /var/opt/jfrog/artifactory/lost+found"]

--- a/openshift/artifactory/artifactory-ha-nfs/artifactory-secondary-deployment.yaml
+++ b/openshift/artifactory/artifactory-ha-nfs/artifactory-secondary-deployment.yaml
@@ -31,12 +31,6 @@ objects:
                 serviceAccountName: ${SERVICE_ACCOUNT}
 
                 initContainers:
-                  - name: set-volume-ownership
-                    image: ${INIT_CONTAINER_IMAGE}
-                    command: ["sh", "-c", "chown -R 1030:1030 /var/opt/jfrog/artifactory"]
-                    volumeMounts:
-                      - name: artifactory
-                        mountPath: /var/opt/jfrog/artifactory
                   - name: remove-lost-found
                     image: ${INIT_CONTAINER_IMAGE}
                     command: ["sh", "-c", "rm -rf /var/opt/jfrog/artifactory/lost+found"]

--- a/openshift/artifactory/artifactory-ha-no-nfs/artifactory-primary-deployment.yaml
+++ b/openshift/artifactory/artifactory-ha-no-nfs/artifactory-primary-deployment.yaml
@@ -30,12 +30,6 @@ objects:
                 serviceAccountName: ${SERVICE_ACCOUNT}
 
                 initContainers:
-                  - name: set-volume-ownership
-                    image: ${INIT_CONTAINER_IMAGE}
-                    command: ["sh", "-c", "chown -R 1030:1030 /var/opt/jfrog/artifactory"]
-                    volumeMounts:
-                      - name: artifactory-data
-                        mountPath: /var/opt/jfrog/artifactory
                   - name: remove-lost-found
                     image: ${INIT_CONTAINER_IMAGE}
                     command: ["sh", "-c", "rm -rf /var/opt/jfrog/artifactory/lost+found"]

--- a/openshift/artifactory/artifactory-ha-no-nfs/artifactory-secondary-deployment.yaml
+++ b/openshift/artifactory/artifactory-ha-no-nfs/artifactory-secondary-deployment.yaml
@@ -30,12 +30,6 @@ objects:
                 serviceAccountName: ${SERVICE_ACCOUNT}
 
                 initContainers:
-                  - name: set-volume-ownership
-                    image: ${INIT_CONTAINER_IMAGE}
-                    command: ["sh", "-c", "chown -R 1030:1030 /var/opt/jfrog/artifactory"]
-                    volumeMounts:
-                      - name: artifactory-data
-                        mountPath: /var/opt/jfrog/artifactory
                   - name: remove-lost-found
                     image: ${INIT_CONTAINER_IMAGE}
                     command: ["sh", "-c", "rm -rf /var/opt/jfrog/artifactory/lost+found"]


### PR DESCRIPTION
This is a fix for #144 

When running deployment configs for Artifactory HA the init-containers get permission denied. This is expected OpenShift behaviour as the init-containers as run as arbitrary UID and cannot do "chown":

```
$ oc logs artifactory-primary-2-b854q -c set-volume-ownership
chown: /var/opt/jfrog/artifactory: Operation not permitted
chown: /var/opt/jfrog/artifactory: Operation not permitted
```

To replicate the above issue run artifactory HA and postgres in separate projects. This is key to testing this as the postgres setup wants the user to add artifactory service account in anyuid scc.

To fix this, I have removed the chown init-containers as they are no longer needed in verison 6.9. This is tested in OpenShift 3.11 and is working.