### PR TITLE
Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
+# DEPRECATED
+This repository's examples are deprecated and are not maintained anymore.<br>
+You should now use the [official JFrog Platform distributions](https://www.jfrog.com/confluence/display/JFROG/Install).
+
 # Artifactory Docker Examples
 This repository provides some examples that show different ways to run Artifactory with Docker orchestration tools.   
 For more detailed documentation on running Artifactory with Docker, please refer to [Running with Docker](https://www.jfrog.com/confluence/display/RTF/Running+with+Docker) in the JFrog Artifactory User Guide
 
-
 ## Docker
 To learn more about Docker and how to set it up, please refer to the [Docker](https://docs.docker.com) documentation.  
- 
 
 ## Examples
 The following examples are available
-- [Docker compose](docker-compose)
-- [Docker Swarm](swarm)
+- [Docker compose](docker-compose) (Deprecated)
+- [Docker Swarm](swarm) (Deprecated)
 - [Kubernetes](kubernetes) (Deprecated)
 - [OpenShift](openshift) (Deprecated)
+- [DC/OS](dc-os) (Deprecated)
 - [Helm Charts](https://github.com/jfrog/charts)
-- [DC/OS](dc-os)
 
 **NOTE**: We have moved our Helm charts to [jfrog/charts](https://github.com/jfrog/charts)

--- a/docker-compose/artifactory/README.md
+++ b/docker-compose/artifactory/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED
+[JFrog Artifactory](https://jfrog.com/artifactory/) is now distributed with an [official Docker-compose installer](https://www.jfrog.com/confluence/display/JFROG/Installing+Artifactory).<br>
+The current Docker-compose examples will not be maintained anymore.
+
 # Artifactory Docker Compose Examples
 This directory provides some examples that show different ways to run Artifactory with Docker Compose.  
 To learn more about Docker and how to set it up, please refer to the [Docker](https://docs.docker.com) and [Docker Compose](https://docs.docker.com/compose/overview/) documentation.  

--- a/docker-compose/xray/README.md
+++ b/docker-compose/xray/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED
+[JFrog Xray](https://jfrog.com/xray/) is now distributed with an [official Docker-compose installer](https://www.jfrog.com/confluence/display/JFROG/Installing+Xray).<br>
+The current Docker-compose examples will not be maintained anymore.
+
 # Xray Docker Compose Examples
 
 This directory provides some examples that show different ways to run Xray with Docker Compose.


### PR DESCRIPTION
This repository is not maintained anymore and needs to be deprecated.
Users should move to use the [official JFrog distributions](https://www.jfrog.com/confluence/display/JFROG/Install).

